### PR TITLE
Fix sRGB to Lab conversion

### DIFF
--- a/deltae
+++ b/deltae
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 # Requires:
-#   python3-opencv
+#   python3-imageio
 #   python3-numpy
 #   python3-colour (recent version needed, see below):
 #      pip3 install colour-science
@@ -10,10 +10,8 @@
 MAX_DELTA_E = 2.3
 MAX_AVG_DELTA_E = MAX_DELTA_E / 3.
 
-import cv2
 import colour
 import numpy
-import os
 import sys
 
 if "delta_E" not in dir(colour):
@@ -23,11 +21,13 @@ if "delta_E" not in dir(colour):
 expected = sys.argv[1]
 output = sys.argv[2]
 
-expected_rgb = cv2.imread(expected)
-output_rgb = cv2.imread(output)
+expected_rgb = colour.read_image(expected, method="Imageio")
+output_rgb = colour.read_image(output, method="Imageio")
 
-expected_lab = cv2.cvtColor(expected_rgb, cv2.COLOR_RGB2Lab)
-output_lab = cv2.cvtColor(output_rgb, cv2.COLOR_RGB2Lab)
+expected_lab = colour.XYZ_to_Lab(colour.sRGB_to_XYZ(expected_rgb,
+                                                    chromatic_adaptation_method="Bradford"))
+output_lab = colour.XYZ_to_Lab(colour.sRGB_to_XYZ(output_rgb,
+                                                  chromatic_adaptation_method="Bradford"))
 
 delta_E = colour.delta_E(expected_lab, output_lab, method="CIE 2000")
 

--- a/deltae
+++ b/deltae
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 # Requires:
-#   python3-imageio
-#   python3-numpy
 #   python3-colour (recent version needed, see below):
 #      pip3 install colour-science
 


### PR DESCRIPTION
There are several problems with the OpenCV approach:

1. `cv2.imread()` notoriously returns images in BGR plane order, so `COLOR_BGR2Lab` enum is needed instead of `COLOR_RGB2Lab` for the conversion
2. Even then, for uint8 BGR input, Lab output is funnily scaled to uint8 as well [1], so another conversion to float beforehand is needed

So input to `colour.delta_E()` was rather non-sensical...

3. Further, the docs don't mention it, but luckily linearization from sRGB EOTF is hard-coded in the source code for the BGR2Lab conversion; there is no control over it however.

This proposal relies just on `colour` [2] so everything ties up together consistently.

[1] https://docs.opencv.org/master/de/d25/imgproc_color_conversions.html#color_convert_rgb_lab
[2] https://colour.readthedocs.io/en/latest/generated/colour.sRGB_to_XYZ.html