### PR TITLE
will work also inside virtualenv

### DIFF
--- a/deltae
+++ b/deltae
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Requires:
 #   python3-scipy >= 1.1.0
@@ -10,6 +10,7 @@
 #   python3-colour-science >= 0.3.14
 #     or install the latest from PyPi if not provided as system package:
 #       pip3 install colour-science
+#   packaging
 
 # Maximum delta allowed, above this value the difference can be detected
 MAX_DELTA_E = 2.3


### PR DESCRIPTION
The absolute python3 path will lead to ModuleNotFoundError when used inside a virtualenv.

Setup virtualenv:
➜  ~ python3 -mvenv virtualenv/darktable
➜  ~ source virtualenv/darktable/bin/activate
(darktable) ➜  ~ pip install scipy six pillow imageio colour-science packaging

Run tests:
(darktable) ➜  integration git:(5b47e86) ✗ ./run.sh 
Test 0000-nop
      Image mire1.cr2
      CPU & GPU version differ by 65133 pixels
      CPU vs. GPU report :
      ----------------------------------
      Max dE                   : 19.23852
      Avg dE                   : 0.02056
      Std dE                   : 0.17950
...

Using ubuntu20.04: Python 3.8.10

(darktable) ➜  ~ pip freeze
colour-science==0.4.1
imageio==2.19.3
numpy==1.22.4
packaging==21.3
Pillow==9.1.1
pyparsing==3.0.9
scipy==1.8.1
six==1.16.0
typing-extensions==4.2.0

(darktable) ➜  ~ which python3
/home/goetz/virtualenv/darktable/bin/python3