### PR TITLE
Make sure about the interpolators

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Needed tools : zopflipng
 2. Start darktable, open one test image (or add a new one if needed)
 
 3. Do a dev using whatever module
+   (please make sure you are using lanczos3 for the pixel interpolator and
+     bicubic for warp interpolator in your preferences)
 
 4. Copy the resulting .xmp into <nnnn>-<meaningful name>
 

--- a/run.sh
+++ b/run.sh
@@ -143,6 +143,8 @@ for dir in $TESTS; do
                  --conf resourcelevel=reference \
                  --conf worker_threads=4 -t 4 \
                  --conf plugins/lighttable/export/force_lcms2=FALSE \
+                 --conf plugins/lighttable/export/pixel_interpolator=lanczos3 \
+                 --conf plugins/lighttable/export/pixel_interpolator_warp=bicubic \
                  --conf plugins/lighttable/export/iccintent=0"
 
             # Some // loops seems to not honor the omp_set_num_threads() in


### PR DESCRIPTION
While experimenting with scaling i always checked the darktable-test 0000-nop for correctness.

This drove me crazy as i sometimes had very bad results.

This pr specifies the used interpolators in run.sh

@TurboGit i know you won't like this suggestion but as we always do some interpolation while exporting i would suggest to change the scaling interpolator to bicubic too for less false-positive errors (lanczos3 likes to overshoot a lot). Unfortunately this would require updating the reference images.   