### PR TITLE
Integration tests can now run on macOS

### DIFF
--- a/count-diff-pixels
+++ b/count-diff-pixels
@@ -1,5 +1,4 @@
-#!/bin/python3
-
+#!/usr/bin/env python3
 import numpy as np
 from PIL import Image
 import argparse

--- a/deltae
+++ b/deltae
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Requires:
 #   python3-scipy >= 1.1.0

--- a/readme.mac.md
+++ b/readme.mac.md
@@ -1,0 +1,35 @@
+# Instructions for macOS 
+MacOS is shipped with its own version of python, getopt and is not using bash but zsh. 
+This gives issues with the python environment and the bash script when running the tests. 
+
+This readme assumes that you have installed brew and are able to build and run darktable.
+
+## Install brew dependencies.
+The standard macOS tools are given issues, so install GNU versions.
+
+```bash
+brew install coreutils
+brew install gnu-getopt
+brew install bash
+```
+
+## Create the python environment 
+The next step is to create a python environment and install the required packages.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install imageio colour-science packaging numpy Pillow scipy matplotlib
+```
+
+## Run the tests
+Once this is ensured, the right paths must be set before the test can run. Additionally, 
+reactive the python virtual evn if not already done.
+
+```bash
+export DARKTABLE_CLI="$PWD/../../../build/bin/darktable-cli"
+export PATH="/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+export XDG_DATA_DIRS="/opt/homebrew/share:/usr/local/share:/usr/share"
+source ./.venv/bin/activate
+/opt/homebrew/bin/bash ./run 0001-exposure
+```


### PR DESCRIPTION
I have updated the integration tests so that they run on macOS:

1) Updated the python scripts to be more portable. The python scripts do now honour a virtual env if loaded, and are not fixed on the system wide python installation but will fall back to it.

2) Added the macOS installation instructions,